### PR TITLE
feat: export ast types

### DIFF
--- a/packages/pg-parser/package.json
+++ b/packages/pg-parser/package.json
@@ -32,6 +32,21 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.cjs"
+    },
+    "./15/types": {
+      "import": "./dist/types/15.js",
+      "types": "./dist/types/15.ts",
+      "default": "./dist/types/15.cjs"
+    },
+    "./16/types": {
+      "import": "./dist/types/16.js",
+      "types": "./dist/types/16.ts",
+      "default": "./dist/types/16.cjs"
+    },
+    "./17/types": {
+      "import": "./dist/types/17.js",
+      "types": "./dist/types/17.ts",
+      "default": "./dist/types/17.cjs"
     }
   },
   "dependencies": {

--- a/packages/pg-parser/src/index.ts
+++ b/packages/pg-parser/src/index.ts
@@ -10,7 +10,7 @@ export type {
   WrappedParseError,
   WrappedParseResult,
   WrappedParseSuccess,
-} from './types.js';
+} from './types/index.js';
 export {
   getSupportedVersions,
   isParseResultVersion,

--- a/packages/pg-parser/src/pg-parser.test.ts
+++ b/packages/pg-parser/src/pg-parser.test.ts
@@ -1,7 +1,7 @@
 import { stripIndent } from 'common-tags';
 import { describe, expect, it } from 'vitest';
 import { PgParser } from './pg-parser.js';
-import type { ParseResult } from './types.js';
+import type { ParseResult } from './types/index.js';
 import { isParseResultVersion, unwrapParseResult } from './util.js';
 
 describe('pg-parser', () => {

--- a/packages/pg-parser/src/pg-parser.ts
+++ b/packages/pg-parser/src/pg-parser.ts
@@ -6,9 +6,9 @@ import {
 import type {
   MainModule,
   PgParserModule,
-  WrappedParseResult,
   SupportedVersion,
-} from './types.js';
+  WrappedParseResult,
+} from './types/index.js';
 import { isSupportedVersion } from './util.js';
 
 export type PgParserOptions<Version extends SupportedVersion> = {

--- a/packages/pg-parser/src/types/15.ts
+++ b/packages/pg-parser/src/types/15.ts
@@ -1,0 +1,5 @@
+import type { ParseResult } from '../../wasm/15/pg-parser-types.js';
+export type ParseResult15 = ParseResult;
+
+export * from '../../wasm/15/pg-parser-types.js';
+export * from '../../wasm/15/pg-parser-enums.js';

--- a/packages/pg-parser/src/types/16.ts
+++ b/packages/pg-parser/src/types/16.ts
@@ -1,0 +1,5 @@
+import type { ParseResult } from '../../wasm/16/pg-parser-types.js';
+export type ParseResult16 = ParseResult;
+
+export * from '../../wasm/16/pg-parser-types.js';
+export * from '../../wasm/16/pg-parser-enums.js';

--- a/packages/pg-parser/src/types/17.ts
+++ b/packages/pg-parser/src/types/17.ts
@@ -1,0 +1,5 @@
+import type { ParseResult } from '../../wasm/17/pg-parser-types.js';
+export type ParseResult17 = ParseResult;
+
+export * from '../../wasm/17/pg-parser-types.js';
+export * from '../../wasm/17/pg-parser-enums.js';

--- a/packages/pg-parser/src/types/index.ts
+++ b/packages/pg-parser/src/types/index.ts
@@ -1,13 +1,13 @@
-import type { MainModule as MainModule15 } from '../wasm/15/pg-parser.js';
-import type { MainModule as MainModule16 } from '../wasm/16/pg-parser.js';
-import type { MainModule as MainModule17 } from '../wasm/17/pg-parser.js';
+import type { MainModule as MainModule15 } from '../../wasm/15/pg-parser.js';
+import type { MainModule as MainModule16 } from '../../wasm/16/pg-parser.js';
+import type { MainModule as MainModule17 } from '../../wasm/17/pg-parser.js';
 
-import type { ParseResult as ParseResult15 } from '../wasm/15/pg-parser-types.js';
-import type { ParseResult as ParseResult16 } from '../wasm/16/pg-parser-types.js';
-import type { ParseResult as ParseResult17 } from '../wasm/17/pg-parser-types.js';
+import type { ParseResult15 } from './15.js';
+import type { ParseResult16 } from './16.js';
+import type { ParseResult17 } from './17.js';
 
-import type { SUPPORTED_VERSIONS } from './constants.js';
-import type { ParseError } from './errors.js';
+import type { SUPPORTED_VERSIONS } from '../constants.js';
+import type { ParseError } from '../errors.js';
 
 export type SupportedVersion = (typeof SUPPORTED_VERSIONS)[number];
 

--- a/packages/pg-parser/src/util.ts
+++ b/packages/pg-parser/src/util.ts
@@ -3,7 +3,7 @@ import type {
   ParseResult,
   SupportedVersion,
   WrappedParseResult,
-} from './types.js';
+} from './types/index.js';
 
 /**
  * Unwraps a `WrappedParseResult` by throwing an error if the result

--- a/packages/pg-parser/tsup.config.ts
+++ b/packages/pg-parser/tsup.config.ts
@@ -2,7 +2,12 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig([
   {
-    entry: ['src/index.ts'],
+    entry: [
+      'src/index.ts',
+      'src/types/15.ts',
+      'src/types/16.ts',
+      'src/types/17.ts',
+    ],
     format: ['cjs', 'esm'],
     outDir: 'dist',
     sourcemap: true,


### PR DESCRIPTION
Exports the AST types for each PG version. These are available at `@supabase/pg-parser/<version>/types`:

```ts
import { SelectStmt } from '@supabase/pg-parser/17/types'
// ...
```