### PR TITLE
fix: generate types as type declaration files

### DIFF
--- a/packages/pg-parser/package.json
+++ b/packages/pg-parser/package.json
@@ -29,23 +29,23 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.js",
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.cjs"
     },
     "./15/types": {
+      "types": "./dist/types/15.d.ts",
       "import": "./dist/types/15.js",
-      "types": "./dist/types/15.ts",
       "default": "./dist/types/15.cjs"
     },
     "./16/types": {
+      "types": "./dist/types/16.d.ts",
       "import": "./dist/types/16.js",
-      "types": "./dist/types/16.ts",
       "default": "./dist/types/16.cjs"
     },
     "./17/types": {
+      "types": "./dist/types/17.d.ts",
       "import": "./dist/types/17.js",
-      "types": "./dist/types/17.ts",
       "default": "./dist/types/17.cjs"
     }
   },

--- a/packages/pg-parser/scripts/generate-types.ts
+++ b/packages/pg-parser/scripts/generate-types.ts
@@ -32,13 +32,13 @@ const options: PgProtoParserOptions = {
     enabled: true,
     wrappedNodeTypeExport: true,
     optionalFields: true,
-    filename: 'pg-parser-types.ts',
+    filename: 'pg-parser-types.d.ts',
     enumsSource: './pg-parser-enums.js',
   },
   enums: {
     enabled: true,
     enumsAsTypeUnion: true,
-    filename: 'pg-parser-enums.ts',
+    filename: 'pg-parser-enums.d.ts',
   },
 };
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently the `.ts` files in `/types` are leaking to the user's compilation target, they are not omitted by `skipLibCheck` as they aren't declaration files.

## What is the new behavior?

All the exported TypeScript files are now declaration files and properly skipped by `skipLibCheck`.

I also moved the `"types"` condition in the first position in `"exports"`, it's usually a best practice as per https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#:~:text=The%20%22types%22%20condition%20should%20always,are%20the%20same%20between%20them.
